### PR TITLE
updated version to 4.0.0b2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.0.0a3" %}
+{% set version = "4.0.0b2" %}
 
 package:
   name: wxpython
@@ -7,7 +7,7 @@ package:
 source:
   fn: wxpython-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/w/wxpython/wxPython-{{ version }}.tar.gz
-  sha256: b147b1a3b4d10da88100fc89a3c4225ba6ff1f89e5da77218989b198ab92b2e6
+  sha256: 1d34c3e2ff475ca6d2a11e8addd0333e4f616cc74f6bfcda5c6e96f51478666d
 
 build:
   number: 0


### PR DESCRIPTION
I tried to test this by bulding on OS-X, but got an odd error on teh setup.py command -- it couldn't find setuptools, even though it was installed into the build environment.

and OS-X is set to skip here anyway -- not sure how we got that built for anaconda.org.

But hopefully we can get this update up there one way or another...