### PR TITLE
Normalize package contents across platforms (#28)

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -10,20 +10,20 @@ jobs:
   strategy:
     maxParallel: 8
     matrix:
-      linux_python2.7:
-        CONFIG: linux_python2.7
+      linux_python2.7.____cpython:
+        CONFIG: linux_python2.7.____cpython
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
-      linux_python3.6:
-        CONFIG: linux_python3.6
+      linux_python3.6.____cpython:
+        CONFIG: linux_python3.6.____cpython
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
-      linux_python3.7:
-        CONFIG: linux_python3.7
+      linux_python3.7.____cpython:
+        CONFIG: linux_python3.7.____cpython
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
-      linux_python3.8:
-        CONFIG: linux_python3.8
+      linux_python3.8.____cpython:
+        CONFIG: linux_python3.8.____cpython
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
   steps:

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -49,3 +49,4 @@ jobs:
 
   - publish: build_artifacts
     artifact: CondaBldDir_$(CONFIG)
+    condition: succeededOrFailed()

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -42,3 +42,10 @@ jobs:
     displayName: Run docker build
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
+  - script: |
+        set -x
+        ls
+    displayName: List Default Working Dir
+
+  - publish: build_artifacts
+    artifact: CondaBldDir

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -48,4 +48,4 @@ jobs:
     displayName: List Default Working Dir
 
   - publish: build_artifacts
-    artifact: CondaBldDir
+    artifact: CondaBldDir_$(CONFIG)

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -5,22 +5,22 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-10.13
+    vmImage: macOS-10.14
   timeoutInMinutes: 360
   strategy:
     maxParallel: 8
     matrix:
-      osx_python2.7:
-        CONFIG: osx_python2.7
+      osx_python2.7.____cpython:
+        CONFIG: osx_python2.7.____cpython
         UPLOAD_PACKAGES: True
-      osx_python3.6:
-        CONFIG: osx_python3.6
+      osx_python3.6.____cpython:
+        CONFIG: osx_python3.6.____cpython
         UPLOAD_PACKAGES: True
-      osx_python3.7:
-        CONFIG: osx_python3.7
+      osx_python3.7.____cpython:
+        CONFIG: osx_python3.7.____cpython
         UPLOAD_PACKAGES: True
-      osx_python3.8:
-        CONFIG: osx_python3.8
+      osx_python3.8.____cpython:
+        CONFIG: osx_python3.8.____cpython
         UPLOAD_PACKAGES: True
 
   steps:
@@ -82,4 +82,4 @@ jobs:
     displayName: Upload package
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
-    condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))
+    condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -83,3 +83,5 @@ jobs:
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
     condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))
+  - publish: /usr/local/miniconda/conda-bld
+    artifact: CondaBldDir

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -85,3 +85,4 @@ jobs:
     condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))
   - publish: /usr/local/miniconda/conda-bld
     artifact: CondaBldDir_$(CONFIG)
+    condition: succeededOrFailed()

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -84,4 +84,4 @@ jobs:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
     condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))
   - publish: /usr/local/miniconda/conda-bld
-    artifact: CondaBldDir
+    artifact: CondaBldDir_$(CONFIG)

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -10,16 +10,16 @@ jobs:
   strategy:
     maxParallel: 4
     matrix:
-      win_c_compilervs2015cxx_compilervs2015python3.6vc14:
-        CONFIG: win_c_compilervs2015cxx_compilervs2015python3.6vc14
+      win_c_compilervs2015cxx_compilervs2015python3.6.____cpythonvc14:
+        CONFIG: win_c_compilervs2015cxx_compilervs2015python3.6.____cpythonvc14
         CONDA_BLD_PATH: D:\\bld\\
         UPLOAD_PACKAGES: True
-      win_c_compilervs2015cxx_compilervs2015python3.7vc14:
-        CONFIG: win_c_compilervs2015cxx_compilervs2015python3.7vc14
+      win_c_compilervs2015cxx_compilervs2015python3.7.____cpythonvc14:
+        CONFIG: win_c_compilervs2015cxx_compilervs2015python3.7.____cpythonvc14
         CONDA_BLD_PATH: D:\\bld\\
         UPLOAD_PACKAGES: True
-      win_c_compilervs2015cxx_compilervs2015python3.8vc14:
-        CONFIG: win_c_compilervs2015cxx_compilervs2015python3.8vc14
+      win_c_compilervs2015cxx_compilervs2015python3.8.____cpythonvc14:
+        CONFIG: win_c_compilervs2015cxx_compilervs2015python3.8.____cpythonvc14
         CONDA_BLD_PATH: D:\\bld\\
         UPLOAD_PACKAGES: True
   steps:
@@ -66,7 +66,7 @@ jobs:
       inputs:
         packageSpecs: 'python=3.6 conda-build conda conda-forge::conda-forge-ci-setup=2' # Optional
         installOptions: "-c conda-forge"
-        updateConda: false
+        updateConda: true
       displayName: Install conda-build and activate environment
 
     - script: set PYTHONUNBUFFERED=1
@@ -108,4 +108,4 @@ jobs:
       displayName: Upload package
       env:
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)
-      condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))
+      condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -110,5 +110,6 @@ jobs:
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)
       condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))
 
-    - publish: D:\bld
+    - publish: $(CONDA_BLD_PATH)
       artifact: CondaBldDir_$(CONFIG)
+      condition: succeededOrFailed()

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -111,4 +111,4 @@ jobs:
       condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))
 
     - publish: D:\bld
-      artifact: CondaBldDir
+      artifact: CondaBldDir_$(CONFIG)

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -109,3 +109,6 @@ jobs:
       env:
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)
       condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))
+
+    - publish: D:\bld
+      artifact: CondaBldDir

--- a/.ci_support/linux_python2.7.____cpython.yaml
+++ b/.ci_support/linux_python2.7.____cpython.yaml
@@ -51,7 +51,7 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '3.6'
+- 2.7.* *_cpython
 xz:
 - '5.2'
 zlib:

--- a/.ci_support/linux_python3.6.____cpython.yaml
+++ b/.ci_support/linux_python3.6.____cpython.yaml
@@ -1,37 +1,47 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '9'
+- '7'
+cairo:
+- '1.16'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '9'
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
 expat:
 - '2.2'
+glib:
+- '2.58'
+gst_plugins_base:
+- 1.14.4
+gstreamer:
+- 1.14.4
 jpeg:
 - '9'
-libiconv:
-- '1.15'
 libpng:
 - '1.6'
-macos_machine:
-- x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
+libxml2:
+- '2.9'
+pango:
+- '1.42'
 pin_run_as_build:
+  cairo:
+    max_pin: x.x
   expat:
     max_pin: x.x
   jpeg:
     max_pin: x
-  libiconv:
-    max_pin: x.x
   libpng:
+    max_pin: x.x
+  libxml2:
+    max_pin: x.x
+  pango:
     max_pin: x.x
   python:
     min_pin: x.x
@@ -41,7 +51,7 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '2.7'
+- 3.6.* *_cpython
 xz:
 - '5.2'
 zlib:

--- a/.ci_support/linux_python3.7.____cpython.yaml
+++ b/.ci_support/linux_python3.7.____cpython.yaml
@@ -51,7 +51,7 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '3.8'
+- 3.7.* *_cpython
 xz:
 - '5.2'
 zlib:

--- a/.ci_support/linux_python3.8.____cpython.yaml
+++ b/.ci_support/linux_python3.8.____cpython.yaml
@@ -1,37 +1,47 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '9'
+- '7'
+cairo:
+- '1.16'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '9'
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
 expat:
 - '2.2'
+glib:
+- '2.58'
+gst_plugins_base:
+- 1.14.4
+gstreamer:
+- 1.14.4
 jpeg:
 - '9'
-libiconv:
-- '1.15'
 libpng:
 - '1.6'
-macos_machine:
-- x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
+libxml2:
+- '2.9'
+pango:
+- '1.42'
 pin_run_as_build:
+  cairo:
+    max_pin: x.x
   expat:
     max_pin: x.x
   jpeg:
     max_pin: x
-  libiconv:
-    max_pin: x.x
   libpng:
+    max_pin: x.x
+  libxml2:
+    max_pin: x.x
+  pango:
     max_pin: x.x
   python:
     min_pin: x.x
@@ -41,7 +51,7 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '3.6'
+- 3.8.* *_cpython
 xz:
 - '5.2'
 zlib:

--- a/.ci_support/osx_python2.7.____cpython.yaml
+++ b/.ci_support/osx_python2.7.____cpython.yaml
@@ -1,47 +1,37 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '7'
-cairo:
-- '1.16'
+- '9'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '7'
-docker_image:
-- condaforge/linux-anvil-comp7
+- '9'
 expat:
 - '2.2'
-glib:
-- '2.58'
-gst_plugins_base:
-- 1.14.4
-gstreamer:
-- 1.14.4
 jpeg:
 - '9'
+libiconv:
+- '1.15'
 libpng:
 - '1.6'
-libxml2:
-- '2.9'
-pango:
-- '1.42'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
 pin_run_as_build:
-  cairo:
-    max_pin: x.x
   expat:
     max_pin: x.x
   jpeg:
     max_pin: x
+  libiconv:
+    max_pin: x.x
   libpng:
-    max_pin: x.x
-  libxml2:
-    max_pin: x.x
-  pango:
     max_pin: x.x
   python:
     min_pin: x.x
@@ -51,7 +41,7 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '2.7'
+- 2.7.* *_cpython
 xz:
 - '5.2'
 zlib:

--- a/.ci_support/osx_python3.6.____cpython.yaml
+++ b/.ci_support/osx_python3.6.____cpython.yaml
@@ -41,7 +41,7 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '3.8'
+- 3.6.* *_cpython
 xz:
 - '5.2'
 zlib:

--- a/.ci_support/osx_python3.7.____cpython.yaml
+++ b/.ci_support/osx_python3.7.____cpython.yaml
@@ -41,7 +41,7 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '3.7'
+- 3.7.* *_cpython
 xz:
 - '5.2'
 zlib:

--- a/.ci_support/osx_python3.8.____cpython.yaml
+++ b/.ci_support/osx_python3.8.____cpython.yaml
@@ -1,47 +1,37 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '7'
-cairo:
-- '1.16'
+- '9'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '7'
-docker_image:
-- condaforge/linux-anvil-comp7
+- '9'
 expat:
 - '2.2'
-glib:
-- '2.58'
-gst_plugins_base:
-- 1.14.4
-gstreamer:
-- 1.14.4
 jpeg:
 - '9'
+libiconv:
+- '1.15'
 libpng:
 - '1.6'
-libxml2:
-- '2.9'
-pango:
-- '1.42'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
 pin_run_as_build:
-  cairo:
-    max_pin: x.x
   expat:
     max_pin: x.x
   jpeg:
     max_pin: x
+  libiconv:
+    max_pin: x.x
   libpng:
-    max_pin: x.x
-  libxml2:
-    max_pin: x.x
-  pango:
     max_pin: x.x
   python:
     min_pin: x.x
@@ -51,7 +41,7 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '3.7'
+- 3.8.* *_cpython
 xz:
 - '5.2'
 zlib:

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.6.____cpythonvc14.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.6.____cpythonvc14.yaml
@@ -13,7 +13,7 @@ pin_run_as_build:
   vc:
     max_pin: x
 python:
-- '3.7'
+- 3.6.* *_cpython
 vc:
 - '14'
 zip_keys:

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.7.____cpythonvc14.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.7.____cpythonvc14.yaml
@@ -13,7 +13,7 @@ pin_run_as_build:
   vc:
     max_pin: x
 python:
-- '3.6'
+- 3.7.* *_cpython
 vc:
 - '14'
 zip_keys:

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.8.____cpythonvc14.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.8.____cpythonvc14.yaml
@@ -13,7 +13,7 @@ pin_run_as_build:
   vc:
     max_pin: x
 python:
-- '3.8'
+- 3.8.* *_cpython
 vc:
 - '14'
 zip_keys:

--- a/README.md
+++ b/README.md
@@ -37,80 +37,80 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_python2.7</td>
+              <td>linux_python2.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/wxpython-feedstock?branchName=master&jobName=linux&configuration=linux_python2.7" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/wxpython-feedstock?branchName=master&jobName=linux&configuration=linux_python2.7.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_python3.6</td>
+              <td>linux_python3.6.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/wxpython-feedstock?branchName=master&jobName=linux&configuration=linux_python3.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/wxpython-feedstock?branchName=master&jobName=linux&configuration=linux_python3.6.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_python3.7</td>
+              <td>linux_python3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/wxpython-feedstock?branchName=master&jobName=linux&configuration=linux_python3.7" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/wxpython-feedstock?branchName=master&jobName=linux&configuration=linux_python3.7.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_python3.8</td>
+              <td>linux_python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/wxpython-feedstock?branchName=master&jobName=linux&configuration=linux_python3.8" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/wxpython-feedstock?branchName=master&jobName=linux&configuration=linux_python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_python2.7</td>
+              <td>osx_python2.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/wxpython-feedstock?branchName=master&jobName=osx&configuration=osx_python2.7" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/wxpython-feedstock?branchName=master&jobName=osx&configuration=osx_python2.7.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_python3.6</td>
+              <td>osx_python3.6.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/wxpython-feedstock?branchName=master&jobName=osx&configuration=osx_python3.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/wxpython-feedstock?branchName=master&jobName=osx&configuration=osx_python3.6.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_python3.7</td>
+              <td>osx_python3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/wxpython-feedstock?branchName=master&jobName=osx&configuration=osx_python3.7" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/wxpython-feedstock?branchName=master&jobName=osx&configuration=osx_python3.7.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_python3.8</td>
+              <td>osx_python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/wxpython-feedstock?branchName=master&jobName=osx&configuration=osx_python3.8" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/wxpython-feedstock?branchName=master&jobName=osx&configuration=osx_python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_c_compilervs2015cxx_compilervs2015python3.6vc14</td>
+              <td>win_c_compilervs2015cxx_compilervs2015python3.6.____cpythonvc14</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/wxpython-feedstock?branchName=master&jobName=win&configuration=win_c_compilervs2015cxx_compilervs2015python3.6vc14" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/wxpython-feedstock?branchName=master&jobName=win&configuration=win_c_compilervs2015cxx_compilervs2015python3.6.____cpythonvc14" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_c_compilervs2015cxx_compilervs2015python3.7vc14</td>
+              <td>win_c_compilervs2015cxx_compilervs2015python3.7.____cpythonvc14</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/wxpython-feedstock?branchName=master&jobName=win&configuration=win_c_compilervs2015cxx_compilervs2015python3.7vc14" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/wxpython-feedstock?branchName=master&jobName=win&configuration=win_c_compilervs2015cxx_compilervs2015python3.7.____cpythonvc14" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_c_compilervs2015cxx_compilervs2015python3.8vc14</td>
+              <td>win_c_compilervs2015cxx_compilervs2015python3.8.____cpythonvc14</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/wxpython-feedstock?branchName=master&jobName=win&configuration=win_c_compilervs2015cxx_compilervs2015python3.8vc14" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/wxpython-feedstock?branchName=master&jobName=win&configuration=win_c_compilervs2015cxx_compilervs2015python3.8.____cpythonvc14" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,7 @@
+setlocal EnableDelayedExpansion
+
+%PYTHON% build.py --jobs=4 --prefix=%PREFIX% build_wx install_wx
+if errorlevel 1 exit 1
+
+%PYTHON% build.py --jobs=4 --prefix=%PREFIX% build_py install_py
+if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+declare -a PLATFORM_BUILD_FLAGS
 if [[ $(uname) == Darwin ]]; then
   # there apparently is a c++ header file being processed as c
   # this is supposed to help against the error "'type_traits' file not found"
@@ -22,12 +23,6 @@ if [[ $(uname) == Darwin ]]; then
   # linking stage, which leads to linking libstdc++ instead of libc++
   export LDFLAGS="$LDFLAGS -stdlib=libc++"
 
-  # build documentation, etg and sip files before the real build starts
-  # required for sip wrappings to be generated
-  # we would only need this if it's a checkout, but we're using a snapshot which includes generated files
-  # https://groups.google.com/d/msg/wxpython-dev/klFi8Ls7Ss8/RitVSbzt-GgJ
-  # $PYTHON build.py dox etg --nodoc sip
-  $PYTHON -m pip install . --no-deps --ignore-installed -vvv
 elif [[ $(uname) == Linux ]]; then
   export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include/GL -I${PREFIX}/include"
 
@@ -38,6 +33,9 @@ elif [[ $(uname) == Linux ]]; then
     export LD_LIBRARY_PATH="${BUILD_PREFIX}/${HOST}/sysroot/usr/lib64"
   fi
 
-  $PYTHON build.py build_wx install_wx --gtk2 --no_magic --prefix=$PREFIX --jobs=$CPU_COUNT
-  $PYTHON build.py build_py install_py --gtk2 --no_magic --prefix=$PREFIX --jobs=$CPU_COUNT
+  PLATFORM_BUILD_FLAGS+=(--gtk2 --no_magic)
+
 fi
+
+$PYTHON build.py build_wx install_wx "${PLATFORM_BUILD_FLAGS[@]}" --prefix=$PREFIX --jobs=$CPU_COUNT
+$PYTHON build.py build_py install_py "${PLATFORM_BUILD_FLAGS[@]}" --prefix=$PREFIX --jobs=$CPU_COUNT

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,10 +14,9 @@ source:
     - patches/0003-Don-t-enable-debug-info-for-all-builds.patch
 
 build:
-  number: 0
+  number: 1
   osx_is_app: True  # [osx]
   skip: True  # [win and vc<14]
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"  # [win]
   missing_dso_whitelist:                                           # [osx]
     - /System/Library/Frameworks/QTKit.framework/Versions/A/QTKit  # [osx]
 


### PR DESCRIPTION
The wxPython CI scripts build macOS like we're building Linux
this will make the same artifacts available on both platforms
(i.e. will provide missing wxPython headers and wx-config on macOS)

This will make it easier for folks who have mixed Python & C++ applications because they really need the same wxWidgets libs.
Fixes #28 

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.
