### PR TITLE
Rebuild python312 0 1 h31f531

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -16,6 +16,10 @@ jobs:
         CONFIG: linux_64_python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_python3.12.____cpython:
+        CONFIG: linux_64_python3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_python3.8.____cpython:
         CONFIG: linux_64_python3.8.____cpython
         UPLOAD_PACKAGES: 'True'

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -14,6 +14,9 @@ jobs:
       osx_64_python3.11.____cpython:
         CONFIG: osx_64_python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
+      osx_64_python3.12.____cpython:
+        CONFIG: osx_64_python3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
       osx_64_python3.8.____cpython:
         CONFIG: osx_64_python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -25,6 +28,9 @@ jobs:
         UPLOAD_PACKAGES: 'True'
       osx_arm64_python3.11.____cpython:
         CONFIG: osx_arm64_python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_python3.12.____cpython:
+        CONFIG: osx_arm64_python3.12.____cpython
         UPLOAD_PACKAGES: 'True'
       osx_arm64_python3.8.____cpython:
         CONFIG: osx_arm64_python3.8.____cpython

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -14,6 +14,9 @@ jobs:
       win_64_python3.11.____cpython:
         CONFIG: win_64_python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
+      win_64_python3.12.____cpython:
+        CONFIG: win_64_python3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
       win_64_python3.8.____cpython:
         CONFIG: win_64_python3.8.____cpython
         UPLOAD_PACKAGES: 'True'

--- a/.ci_support/linux_64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_python3.12.____cpython.yaml
@@ -1,0 +1,51 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cairo:
+- '1'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+expat:
+- '2'
+glib:
+- '2'
+gstreamer:
+- '1.22'
+libjpeg_turbo:
+- '3'
+libpng:
+- '1.6'
+libtiff:
+- '4.6'
+libxml2:
+- '2'
+pango:
+- '1.50'
+pcre2:
+- '10.42'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+target_platform:
+- linux-64
+xz:
+- '5'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+zlib:
+- '1.2'

--- a/.ci_support/migrations/libtiff46.yaml
+++ b/.ci_support/migrations/libtiff46.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-libtiff:
-- '4.6'
-migrator_ts: 1694631046.2977061

--- a/.ci_support/migrations/python312.yaml
+++ b/.ci_support/migrations/python312.yaml
@@ -1,0 +1,38 @@
+migrator_ts: 1695046563
+__migrator:
+    migration_number: 1
+    operation: key_add
+    primary_key: python
+    ordering:
+        python:
+            - 3.6.* *_cpython
+            - 3.7.* *_cpython
+            - 3.8.* *_cpython
+            - 3.9.* *_cpython
+            - 3.10.* *_cpython
+            - 3.11.* *_cpython
+            - 3.12.* *_cpython  # new entry
+            - 3.6.* *_73_pypy
+            - 3.7.* *_73_pypy
+            - 3.8.* *_73_pypy
+            - 3.9.* *_73_pypy
+    paused: false
+    longterm: True
+    pr_limit: 30
+    max_solver_attempts: 6  # this will make the bot retry "not solvable" stuff 6 times
+    exclude:
+      # this shouldn't attempt to modify the python feedstocks
+      - python
+      - pypy3.6
+      - pypy-meta
+      - cross-python
+      - python_abi
+    exclude_pinned_pkgs: false
+
+python:
+  - 3.12.* *_cpython
+# additional entries to add for zip_keys
+numpy:
+  - 1.26
+python_impl:
+  - cpython

--- a/.ci_support/osx_64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_python3.12.____cpython.yaml
@@ -1,0 +1,45 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.12'
+MACOSX_SDK_VERSION:
+- '10.12'
+c_compiler:
+- clang
+c_compiler_version:
+- '16'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '16'
+expat:
+- '2'
+libiconv:
+- '1'
+libjpeg_turbo:
+- '3'
+libpng:
+- '1.6'
+libtiff:
+- '4.6'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pcre2:
+- '10.42'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+target_platform:
+- osx-64
+xz:
+- '5'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+zlib:
+- '1.2'

--- a/.ci_support/osx_arm64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpython.yaml
@@ -1,0 +1,43 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '16'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '16'
+expat:
+- '2'
+libiconv:
+- '1'
+libjpeg_turbo:
+- '3'
+libpng:
+- '1.6'
+libtiff:
+- '4.6'
+macos_machine:
+- arm64-apple-darwin20.0.0
+pcre2:
+- '10.42'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+target_platform:
+- osx-arm64
+xz:
+- '5'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+zlib:
+- '1.2'

--- a/.ci_support/win_64_python3.12.____cpython.yaml
+++ b/.ci_support/win_64_python3.12.____cpython.yaml
@@ -1,0 +1,16 @@
+c_compiler:
+- vs2019
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- vs2019
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+target_platform:
+- win-64

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @constantinpape @ocefpaf @timsnyder
+* @constantinpape @ocefpaf @pauldmccarthy @timsnyder

--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_64_python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2149&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/wxpython-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_python3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_64_python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2149&branchName=main">
@@ -80,6 +87,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2149&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/wxpython-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2149&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/wxpython-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_python3.12.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -111,6 +125,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>osx_arm64_python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2149&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/wxpython-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_python3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_arm64_python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2149&branchName=main">
@@ -136,6 +157,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2149&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/wxpython-feedstock?branchName=main&jobName=win&configuration=win%20win_64_python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2149&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/wxpython-feedstock?branchName=main&jobName=win&configuration=win%20win_64_python3.12.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -283,5 +311,6 @@ Feedstock Maintainers
 
 * [@constantinpape](https://github.com/constantinpape/)
 * [@ocefpaf](https://github.com/ocefpaf/)
+* [@pauldmccarthy](https://github.com/pauldmccarthy/)
 * [@timsnyder](https://github.com/timsnyder/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 
 build:
-  number: 2
+  number: 3
   osx_is_app: true  # [osx]
   missing_dso_whitelist:   # [osx]
     - /System/Library/Frameworks/QTKit.framework/Versions/A/QTKit  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,10 @@ source:
     - patches/0003-Don-t-enable-debug-info-for-all-builds.patch
     - patches/0004-enable-use-of-no_magic-and-install_wx-on-Windows.patch
     - patches/0005-MacOS-no-builtin-3rdparty.patch
+    # Remove unused import which has been removed in cython 3
+    # (https://github.com/wxWidgets/Phoenix/pull/2441)
+    # This patch can be removed in wxpython > 4.2.1
+    - patches/0006-cython3-compat.patch
 
 
 build:

--- a/recipe/patches/0006-cython3-compat.patch
+++ b/recipe/patches/0006-cython3-compat.patch
@@ -1,0 +1,12 @@
+diff --git a/wx/svg/_nanosvg.pyx b/wx/svg/_nanosvg.pyx
+index cda04d5c..d1cae1aa 100644
+--- a/wx/svg/_nanosvg.pyx
++++ b/wx/svg/_nanosvg.pyx
+@@ -42,7 +42,6 @@ for manipulating the SVG shape info in memory.
+ 
+ import sys
+ 
+-cimport cython.object
+ from cpython.buffer cimport (
+     Py_buffer, PyObject_CheckBuffer, PyObject_GetBuffer, PyBUF_SIMPLE,
+     PyBuffer_Release)


### PR DESCRIPTION
Incorporates #116 and #113, by adding a small patch to allow compilation with cython >=3. Note that the patch will need to be removed when the next version of wxpython is released

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
