### PR TITLE
Set GDK_BACKEND=x11 on linux to avoid segmentation faults under Wayland

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,13 +8,14 @@ source:
   url: https://pypi.io/packages/source/w/wxPython/wxPython-{{ version }}.tar.gz
   sha256: 5dbcb0650f67fdc2c5965795a255ffaa3d7b09fb149aa8da2d0d9aa44e38e2ba
   patches:
+    - patches/0001-linux-gdk-backend.patch
     - patches/0003-Don-t-enable-debug-info-for-all-builds.patch
     - patches/0004-enable-use-of-no_magic-and-install_wx-on-Windows.patch
     - patches/0005-MacOS-no-builtin-3rdparty.patch
 
 
 build:
-  number: 0
+  number: 1
   osx_is_app: true  # [osx]
   missing_dso_whitelist:   # [osx]
     - /System/Library/Frameworks/QTKit.framework/Versions/A/QTKit  # [osx]

--- a/recipe/patches/0001-linux-gdk-backend.patch
+++ b/recipe/patches/0001-linux-gdk-backend.patch
@@ -1,0 +1,24 @@
+--- wxPython-4.2.2.orig/wx/__init__.py	2024-10-07 12:55:09.254843799 +0100
++++ wxPython-4.2.2/wx/__init__.py	2024-10-07 12:55:34.619599811 +0100
+@@ -7,6 +7,15 @@
+ # License:     wxWindows License
+ #---------------------------------------------------------------------------
+ 
++import os
++import platform
++
++# Set GDK_BACKEND=x11 on linux, as the conda-forge wxwidgets build
++# is compiled to use GLX, which would cause a segmentation fault
++# when running under Wayland.
++if platform.system() == 'Linux':
++    os.environ['GDK_BACKEND'] = 'x11'
++
+ # Load the main version string into the package namespace
+ import wx.__version__
+ __version__ = wx.__version__.VERSION_STRING
+@@ -20,3 +29,5 @@
+ # Clean up the package namespace
+ del core
+ del wx
++del os
++del platform


### PR DESCRIPTION
The [wxwidgets](conda-forge/wxwidgets-feedstock) conda-forge package is currently built such that the `wx.glcanvas.GLCanvas` class uses GLX for OpenGL interaction. Use of this class causes segmentation faults when running under Wayland, unless the `GDK_BACKEND=x11` environment variable is set. 

This patch will need to be removed if/when the `wxwidgets` package starts being compiled to use EGL rather than GLX.
More details:
 - https://github.com/conda-forge/wxpython-feedstock/pull/122
 - https://github.com/wxWidgets/Phoenix/issues/1923

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
