### PR TITLE
v4.2.1: Pin wxwidgets at 3.2.5, set GDK_BACKEND=x11

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
 
 
 build:
-  number: 6
+  number: 7
   osx_is_app: true  # [osx]
   missing_dso_whitelist:   # [osx]
     - /System/Library/Frameworks/QTKit.framework/Versions/A/QTKit  # [osx]
@@ -48,7 +48,7 @@ requirements:
     - gtk3                # [linux]
     - requests
     - setuptools
-    - wxwidgets
+    - wxwidgets 3.2.5
     - xorg-xineramaproto  # [linux]
     - xorg-libxfixes      # [linux]
     - xorg-libxext        # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - make                                # [unix]
     - pkg-config                          # [not win]
     - sip 6.7.11
-    - setuptools
+    - setuptools 73.*
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ stdlib("c") }}
@@ -48,7 +48,7 @@ requirements:
     - cython >=0.29.32,<3
     - gtk3                # [linux]
     - requests
-    - setuptools
+    - setuptools 73.*
     - wxwidgets 3.2.5
     - xorg-xineramaproto  # [linux]
     - xorg-libxfixes      # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,6 +64,7 @@ requirements:
     - pillow
     - setuptools
     - six
+    - wxwidgets 3.2.5
     # https://github.com/conda-forge/xorg-libxxf86vm-feedstock/issues/5
     - xorg-libxxf86vm  # [linux]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,7 @@ source:
   sha256: e48de211a6606bf072ec3fa778771d6b746c00b7f4b970eb58728ddf56d13d5c
   patches:
     - patches/build.py.patch  # Make sure windows builds don't try to use msgfmt.
+    - patches/0001-linux-gdk-backend.patch
     - patches/0003-Don-t-enable-debug-info-for-all-builds.patch
     - patches/0004-enable-use-of-no_magic-and-install_wx-on-Windows.patch
     - patches/0005-MacOS-no-builtin-3rdparty.patch

--- a/recipe/patches/0001-linux-gdk-backend.patch
+++ b/recipe/patches/0001-linux-gdk-backend.patch
@@ -1,0 +1,24 @@
+--- wxPython-4.2.2.orig/wx/__init__.py	2024-10-07 12:55:09.254843799 +0100
++++ wxPython-4.2.2/wx/__init__.py	2024-10-07 12:55:34.619599811 +0100
+@@ -7,6 +7,15 @@
+ # License:     wxWindows License
+ #---------------------------------------------------------------------------
+ 
++import os
++import platform
++
++# Set GDK_BACKEND=x11 on linux, as the conda-forge wxwidgets build
++# is compiled to use GLX, which would cause a segmentation fault
++# when running under Wayland.
++if platform.system() == 'Linux':
++    os.environ['GDK_BACKEND'] = 'x11'
++
+ # Load the main version string into the package namespace
+ import wx.__version__
+ __version__ = wx.__version__.VERSION_STRING
+@@ -20,3 +29,5 @@
+ # Clean up the package namespace
+ del core
+ del wx
++del os
++del platform


### PR DESCRIPTION
Backporting some fixes to v4.2.1:
 - #125
 - #126 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
